### PR TITLE
Concatenate ino files before building

### DIFF
--- a/esp8266Arduino.mk
+++ b/esp8266Arduino.mk
@@ -124,11 +124,11 @@ DEFINES = $(USER_DEFINE) \
 	-DF_CPU=$(F_CPU) -DARDUINO=$(ARDUINO_VERSION) \
 	-DARDUINO_$(ARDUINO_BOARD) -DESP8266 \
 	-DARDUINO_ARCH_$(shell echo "$(ARDUINO_ARCH)" | tr '[:lower:]' '[:upper:]') \
-	
+
 CORE_INC = $(ARDUINO_HOME)/cores/$(ARDUINO_ARCH) \
 	$(ARDUINO_HOME)/variants/$(VARIANT)
 
-INCLUDES = $(CORE_INC:%=-I%) $(ALIBDIRS:%=-I%) $(ULIBDIRS:%=-I%)
+INCLUDES = $(CORE_INC:%=-I%) $(ALIBDIRS:%=-I%) $(ULIBDIRS:%=-I%) $(USRCDIRS:%=-I%)
 VPATH = . $(CORE_INC) $(ALIBDIRS) $(ULIBDIRS)
 
 #compiler.S.flags=-c -g -x assembler-with-cpp -MMD -mlongcalls

--- a/esp8266Arduino.mk
+++ b/esp8266Arduino.mk
@@ -114,7 +114,7 @@ USER_HPPSRC = $(wildcard $(addsuffix /*.hpp,$(USRCDIRS)))
 LIB_INOSRC = $(wildcard $(addsuffix /*.ino,$(USRCDIRS)))
 
 # object files
-OBJ_FILES = $(addprefix $(BUILD_OUT)/,$(notdir $(LIB_SRC:.c=.c.o) $(LIB_CXXSRC:.cpp=.cpp.o) $(LIB_INOSRC:.ino=.ino.o) $(USER_SRC:.c=.c.o) $(USER_CXXSRC:.cpp=.cpp.o)))
+OBJ_FILES = $(addprefix $(BUILD_OUT)/,$(notdir $(LIB_SRC:.c=.c.o) $(LIB_CXXSRC:.cpp=.cpp.o) $(TARGET).fullino.o $(USER_SRC:.c=.c.o) $(USER_CXXSRC:.cpp=.cpp.o)))
 
 #compiler.cpreprocessor.flags=-D__ets__ -DICACHE_FLASH -U__STRICT_ANSI__ "-I{compiler.sdk.path}/include" "-I{compiler.sdk.path}/lwip/include"
 CPREPROCESSOR_FLAGS = -D__ets__ -DICACHE_FLASH -U__STRICT_ANSI__ -I$(ESPRESSIF_SDK)/include -I$(ESPRESSIF_SDK)/lwip/include
@@ -196,7 +196,10 @@ $(BUILD_OUT)/core/%.cpp.o: %.cpp
 $(BUILD_OUT)/%.c.o: %.c
 	$(CC) -D_TAG_=\"$(TAG)\"  $(DEFINES) $(CFLAGS) $(INCLUDES) -o $@ $<
 
-$(BUILD_OUT)/%.ino.o: %.ino
+$(BUILD_OUT)/%.fullino: $(LIB_INOSRC)
+	-cat $(TARGET).ino $(filter-out $(TARGET).ino,$^) > $@
+
+$(BUILD_OUT)/%.fullino.o: $(BUILD_OUT)/%.fullino
 	$(CXX) -x c++ -D_TAG_=\"$(TAG)\" $(DEFINES) $(CXXFLAGS) $(INCLUDES) $< -o $@
 
 $(BUILD_OUT)/%.cpp.o: %.cpp


### PR DESCRIPTION
As describe in the Adruino Build process
(https://www.arduino.cc/en/Hacking/BuildProcess)
ino files are concateneted before building.
So variable defined in a .ino are available in other one
