### PR TITLE
Work with 2.4.2 (and later) and fix scripts conditions.

### DIFF
--- a/esp32-install.sh
+++ b/esp32-install.sh
@@ -2,7 +2,8 @@
 # Get Arduino core for ESP32 chip
 git clone https://github.com/espressif/arduino-esp32 esp32
 cd esp32 && git submodule update --init --recursive
-if [ "$OSTYPE" == "cygwin" ] || [ "$OSTYPE" == "msys" ]; then
+if [ "$OSTYPE" = "cygwin" ] || [ "$OSTYPE" = "msys" ]
+then
 	chmod +x esp32/tools/get.exe
 	chmod +x esp32/tools/espota.exe
 	chmod +x esp32/tools/gen_esp32part.exe

--- a/esp8266-install-from-git.sh
+++ b/esp8266-install-from-git.sh
@@ -2,7 +2,8 @@
 git clone https://github.com/esp8266/Arduino.git esp8266.git
 
 cd esp8266.git/tools && ./get.py && cd ../..
-if [[ "$OSTYPE" == "cygwin" ]]; then
+if [ "$OSTYPE" = "cygwin" ]
+then
 	chmod +x ./esp8266.git/tools/esptool/esptool.exe
 	chmod +x ./esp8266.git/tools/mkspiffs/mkspiffs.exe
 fi

--- a/esp8266-install.sh
+++ b/esp8266-install.sh
@@ -1,16 +1,17 @@
 #!/bin/sh
-declare ESP8266_VER=2.4.1
+ESP8266_VER=2.4.2
 
-declare DOWNLOAD_CACHE=./download
+DOWNLOAD_CACHE=./download
 mkdir $DOWNLOAD_CACHE
 
-# Get Arduino core for ESP8266 chip
+Get Arduino core for ESP8266 chip
 wget --no-clobber https://github.com/esp8266/Arduino/releases/download/$ESP8266_VER/esp8266-$ESP8266_VER.zip -P $DOWNLOAD_CACHE
 unzip $DOWNLOAD_CACHE/esp8266-$ESP8266_VER.zip
 mkdir esp8266-$ESP8266_VER/package
 wget --no-clobber http://arduino.esp8266.com/versions/$ESP8266_VER/package_esp8266com_index.json -O esp8266-$ESP8266_VER/package/package_esp8266com_index.template.json
 cd esp8266-$ESP8266_VER/tools && ./get.py && cd ../..
-if [ "$OSTYPE" == "cygwin" ] || [ "$OSTYPE" == "msys" ]; then
+if [ "$OSTYPE" = "cygwin" ] || [ "$OSTYPE" = "msys" ]
+then
 	chmod +x ./esp8266-$ESP8266_VER/tools/esptool/esptool.exe
 	chmod +x ./esp8266-$ESP8266_VER/tools/mkspiffs/mkspiffs.exe
 fi

--- a/espXArduino.mk
+++ b/espXArduino.mk
@@ -21,7 +21,10 @@ GREP := grep$(EXEC_EXT)
 SERIAL_PORT ?= /dev/tty.nodemcu
 ARDUINO_ARCH ?= esp8266
 ifeq ($(ARDUINO_ARCH),esp8266)
-	ESP8266_VERSION ?= -2.4.1
+	ESP8266_VERSION ?= 2.4.2
+	ifneq ($(ESP8266_VERSION),.git)
+		ESP8266_VERSION := -$(ESP8266_VERSION)
+	endif
 else
 	ESP8266_VERSION=
 endif
@@ -385,9 +388,10 @@ bin: $(BUILD_OUT)/$(TARGET).bin
 VTABLE_FLAGS=-DVTABLES_IN_FLASH
 
 prelink:
-ifeq ($(ESP8266_VERSION), .git)
+ifneq ("$(wildcard  $(ESPRESSIF_SDK)/ld/eagle.app.v6.common.ld.h)","")
 	$(CC) $(VTABLE_FLAGS) -CC -E -P  $(ESPRESSIF_SDK)/ld/eagle.app.v6.common.ld.h -o $(ESPRESSIF_SDK)/ld/eagle.app.v6.common.ld
 endif
+
 
 $(BUILD_OUT)/core/%.S.o: $(ARDUINO_HOME)/cores/$(ARDUINO_ARCH)/%.S
 	$(CC) $(CPREPROCESSOR_FLAGS) $(ASFLAGS) $(DEFINES) $(CORE_INC:%=-I%) -o $@ $<
@@ -442,7 +446,7 @@ ifeq ($(ARDUINO_ARCH),esp32)
 	$(OBJCOPY_EEP_PATTERN)
 endif
 	$(ESPTOOL) $(OBJCOPY_HEX_PATTERN)
-ifeq ($(ESP8266_VERSION), .git)
+ifneq ("$(wildcard  $(ESPRESSIF_SDK)/ld/eagle.app.v6.common.ld.h)","")
 	@rm $(ESPRESSIF_SDK)/ld/eagle.app.v6.common.ld
 endif
 

--- a/example/esp8266/AdvancedWebServer/Makefile
+++ b/example/esp8266/AdvancedWebServer/Makefile
@@ -2,7 +2,7 @@ ARDUINO_VARIANT = nodemcu
 SERIAL_PORT = /dev/nodemcu
 # uncomment and set the right serial baud according to your sketch (default to 115200)
 #SERIAL_BAUD = 115200
-ESP8266_VERSION=.git
+ESP8266_VERSION=2.4.2
 LOG_SERIAL_TO_FILE=yes
 USER_DEFINE = -D_SSID_=\"YourSSID\" -D_WIFI_PASSWORD_=\"YourPassword\"
 OTA_IP = 192.168.1.184

--- a/example/esp8266/servo/Makefile
+++ b/example/esp8266/servo/Makefile
@@ -1,5 +1,5 @@
 ARDUINO_VARIANT = nodemcu
 SERIAL_PORT = /dev/nodemcu
-ESP8266_VERSION=.git
+ESP8266_VERSION=2.4.2
 include ../../../espXArduino.mk
 


### PR DESCRIPTION
These changes allow the make file to work with version 2.4.2 of the sdk. 
Changed a little so that the dash is not needed on the sdk number (which i missed out at first and took a while to figure out it was needed).

also fix the conditions in the scripts as they caused errors.